### PR TITLE
Go: Pipe compiler tarball to tar instead of saving it to disk

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -3,8 +3,8 @@ FROM registry.nordix.org/eiffel-playground/etos-base-test-runner:$DEBIAN_RELEASE
 
 ARG GO_VERSION
 USER root
-RUN wget "https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz"
-RUN tar -C /usr/local -xzf "go$GO_VERSION.linux-amd64.tar.gz"
+RUN wget -O - "https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz" | \
+    tar -C /usr/local -xzf -
 USER etos
 
 ENV PATH $PATH:/usr/local/go/bin


### PR DESCRIPTION
### Applicable Issues
Fixes https://github.com/eiffel-community/etos/issues/62

### Description of the Change
The downloaded Go compiler tarball used to get stored in a layer in the resulting Docker image, unnecessarily wasting space. By piping the tarball directly to tar we reduce the size of the Docker image by about 115 MB (Go 1.15.3).

### Alternate Designs
We could store the image on disk but delete it in the same RUN directive,

    RUN wget "https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz" && \
        tar -C /usr/local -xzf "go$GO_VERSION.linux-amd64.tar.gz" && \
        rm "go$GO_VERSION.linux-amd64.tar.gz"

but that's more verbose and probably has a higher I/O cost.

### Benefits
Smaller Docker image for the Go-based test runner.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
