### PR TITLE
Add ETR_VERSION for selecting which version of ETR to use

### DIFF
--- a/base/executor.sh
+++ b/base/executor.sh
@@ -11,7 +11,7 @@ if [ $DEV = "true" ] ; then
     ETR_REPOSITORY=${ETR_REPOSITORY:-https://github.com/eiffel-community/etos-test-runner.git}
     ETR_INSTALL="git+$ETR_REPOSITORY@$ETR_BRANCH"
 else
-    ETR_INSTALL="etos_test_runner"
+    ETR_INSTALL="etos_test_runner==$ETR_VERSION"
 fi
 
 pip install $PIP_ARGS $ETR_INSTALL


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
eiffel-community/etos#94

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
This is a required parameter and it requires us to rebuild all
test runner containers that have been built.
This is not a backwards compatible change

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
We could set a default value, which is the "latest" but I do think that making this change now is better and deal with the consequences before there are too many users.

### Benefits
<!-- What benefits will be realized by the change? -->
Today the test runner containers will always install the latest ETR version. This is bad.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
We must always choose a version.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
