### PR TITLE
Add Debian Bullseye support for Base Container

### DIFF
--- a/base/Dockerfile.bullseye
+++ b/base/Dockerfile.bullseye
@@ -1,0 +1,33 @@
+ARG DEBIAN_RELEASE=bullseye
+FROM debian:$DEBIAN_RELEASE
+
+ENV ETOS_CONTEXT="ETR"
+ENV ETR_PYTHON_VERSION=3.9.0
+
+USER root
+
+ENV PYENV_ROOT=/home/etos/.pyenv
+ENV PATH="/home/etos/.pyenv/shims:/home/etos/.pyenv/bin:${PATH}"
+ENV TEST_ARTIFACT_PATH /home/etos/artifacts
+ENV GLOBAL_ARTIFACT_PATH /home/etos/global
+ENV TEST_LOCAL_PATH /home/etos/local
+
+# hadolint ignore=DL3008
+RUN apt-get update -y && \
+    apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev \
+    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+    xz-utils tk-dev libffi-dev liblzma-dev python3-openssl git python3 python3-dev python3-pip \
+    --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -ms /bin/bash etos
+
+USER etos
+WORKDIR /home/etos
+
+RUN echo "eval \"\$(pyenv init -)\"" >> /home/etos/.bashrc && \
+    git clone https://github.com/pyenv/pyenv.git /home/etos/.pyenv && \
+    pyenv install $ETR_PYTHON_VERSION && \
+    pyenv global $ETR_PYTHON_VERSION
+
+COPY executor.sh /home/etos/executor.sh
+ENTRYPOINT ["/home/etos/executor.sh"]


### PR DESCRIPTION
### Applicable Issues
Fix eiffel-community/etos#107

### Description of the Change
Add a Dockerfile that properly builds the base test runner container from Debian Bullseye

### Alternate Designs
None

### Benefits
We can properly build test runner containers from bullseye

### Possible Drawbacks
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>>
