### PR TITLE
update Python test runner

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,5 +1,5 @@
-ARG DEBIAN_RELEASE=buster
-FROM registry.nordix.org/eiffel/etos-base-test-runner:$DEBIAN_RELEASE
+ARG DEBIAN_RELEASE=trixie
+FROM ghcr.io/eiffel-community/etos-base-test-runner:$DEBIAN_RELEASE
 
 ARG PYTHON_VERSION
 # Don't install if python version is already installed.


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/435

### Description of the Change
Update Python test runner to use Debian trixie base image.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com