### PR TITLE
add build args to github workflow main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,11 +39,41 @@ jobs:
         with:
           dockerfile: rust/Dockerfile
 
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      bookworm: ${{ steps.changes.outputs.bookworm }}
+      bullseye: ${{ steps.changes.outputs.bullseye }}
+      python: ${{ steps.changes.outputs.python }}
+      go: ${{ steps.changes.outputs.go }}
+      rust: ${{ steps.changes.outputs.rust }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check for changes
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            bookworm:
+              - 'base/Dockerfile.bookworm'
+            bullseye:
+              - 'base/Dockerfile.bullseye'
+            python:
+              - 'python/Dockerfile'
+              - 'base/Dockerfile.bookworm'
+            go:
+              - 'go/Dockerfile'
+              - 'base/Dockerfile.bookworm'
+            rust:
+              - 'rust/Dockerfile'
+              - 'base/Dockerfile.bookworm'
+
   build-and-push:
     # Only run on push to main branch (PR merges)
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: run-hadolint
+    needs: [run-hadolint, check-changes]
 
     permissions:
       contents: read
@@ -56,35 +86,42 @@ jobs:
             tag: bookworm
             context: base
             build_args: ""
+            should_build: ${{ needs.check-changes.outputs.bookworm == 'true' }}
           - dockerfile: base/Dockerfile.bullseye
             tag: bullseye
             context: base
             build_args: ""
+            should_build: ${{ needs.check-changes.outputs.bullseye == 'true' }}
           - dockerfile: python/Dockerfile
             tag: python
             context: python
             build_args: |
               DEBIAN_RELEASE=bookworm
               PYTHON_VERSION=3.13
+            should_build: ${{ needs.check-changes.outputs.python == 'true' }}
           - dockerfile: go/Dockerfile
             tag: go
             context: go
             build_args: |
               DEBIAN_RELEASE=bookworm
               GO_VERSION=1.25.0
+            should_build: ${{ needs.check-changes.outputs.go == 'true' }}
           - dockerfile: rust/Dockerfile
             tag: rust
             context: rust
             build_args: |
               DEBIAN_RELEASE=bookworm
               RUST_VERSION=1.90.0
+            should_build: ${{ needs.check-changes.outputs.rust == 'true' }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        if: matrix.should_build
 
       - name: Log in to Container Registry
         uses: docker/login-action@v3
+        if: matrix.should_build
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -92,6 +129,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
+        if: matrix.should_build
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/eiffel-community/etos-base-test-runner
@@ -100,9 +138,11 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        if: matrix.should_build
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
+        if: matrix.should_build
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,18 +55,29 @@ jobs:
           - dockerfile: base/Dockerfile.bookworm
             tag: bookworm
             context: base
+            build_args: ""
           - dockerfile: base/Dockerfile.bullseye
             tag: bullseye
             context: base
+            build_args: ""
           - dockerfile: python/Dockerfile
             tag: python
             context: python
+            build_args: |
+              DEBIAN_RELEASE=bookworm
+              PYTHON_VERSION=3.13
           - dockerfile: go/Dockerfile
             tag: go
             context: go
+            build_args: |
+              DEBIAN_RELEASE=bookworm
+              GO_VERSION=1.25.0
           - dockerfile: rust/Dockerfile
             tag: rust
             context: rust
+            build_args: |
+              DEBIAN_RELEASE=bookworm
+              RUST_VERSION=1.90.0
 
     steps:
       - name: Checkout repository
@@ -98,3 +109,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ matrix.build_args }}

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,5 +1,5 @@
-ARG DEBIAN_RELEASE=buster
-FROM registry.nordix.org/eiffel/etos-base-test-runner:$DEBIAN_RELEASE
+ARG DEBIAN_RELEASE=bookworm
+FROM ghcr.io/eiffel-community/etos-base-test-runner:$DEBIAN_RELEASE
 
 ARG GO_VERSION
 USER root

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,5 +1,5 @@
-ARG DEBIAN_RELEASE=buster
-FROM registry.nordix.org/eiffel/etos-base-test-runner:$DEBIAN_RELEASE
+ARG DEBIAN_RELEASE=bookworm
+FROM ghcr.io/eiffel-community/etos-base-test-runner:$DEBIAN_RELEASE
 
 ARG PYTHON_VERSION
 # Don't install if python version is already installed.

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,7 +1,6 @@
 ARG DEBIAN_RELEASE=bookworm
 FROM ghcr.io/eiffel-community/etos-base-test-runner:$DEBIAN_RELEASE
 
-RUN apt update && apt  install -y curl
 ARG RUST_VERSION
 # hadolint ignore=DL4006
 RUN /usr/bin/curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VERSION

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,6 +1,7 @@
-ARG DEBIAN_RELEASE=buster
-FROM registry.nordix.org/eiffel/etos-base-test-runner:$DEBIAN_RELEASE
+ARG DEBIAN_RELEASE=bookworm
+FROM ghcr.io/eiffel-community/etos-base-test-runner:$DEBIAN_RELEASE
 
+RUN apt update && apt  install -y curl
 ARG RUST_VERSION
 # hadolint ignore=DL4006
 RUN /usr/bin/curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VERSION


### PR DESCRIPTION
### Applicable Issues

### Description of the Change
This PR adds docker build args (Python, Go, and Rust versions) to the Github workflow `main.yml`.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com