### PR TITLE
move default build args to Dockerfiles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,33 +85,22 @@ jobs:
           - dockerfile: base/Dockerfile.bookworm
             tag: bookworm
             context: base
-            build_args: ""
             should_build: ${{ needs.check-changes.outputs.bookworm == 'true' }}
           - dockerfile: base/Dockerfile.bullseye
             tag: bullseye
             context: base
-            build_args: ""
             should_build: ${{ needs.check-changes.outputs.bullseye == 'true' }}
           - dockerfile: python/Dockerfile
             tag: python
             context: python
-            build_args: |
-              DEBIAN_RELEASE=bookworm
-              PYTHON_VERSION=3.13
             should_build: ${{ needs.check-changes.outputs.python == 'true' }}
           - dockerfile: go/Dockerfile
             tag: go
             context: go
-            build_args: |
-              DEBIAN_RELEASE=bookworm
-              GO_VERSION=1.25.0
             should_build: ${{ needs.check-changes.outputs.go == 'true' }}
           - dockerfile: rust/Dockerfile
             tag: rust
             context: rust
-            build_args: |
-              DEBIAN_RELEASE=bookworm
-              RUST_VERSION=1.90.0
             should_build: ${{ needs.check-changes.outputs.rust == 'true' }}
 
     steps:

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,7 +1,7 @@
 ARG DEBIAN_RELEASE=bookworm
 FROM ghcr.io/eiffel-community/etos-base-test-runner:$DEBIAN_RELEASE
 
-ARG GO_VERSION
+ARG GO_VERSION=1.25.0
 USER root
 # hadolint ignore=DL4006
 RUN wget -O - --progress=dot:giga "https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz" | \

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,7 +1,7 @@
 ARG DEBIAN_RELEASE=bookworm
 FROM ghcr.io/eiffel-community/etos-base-test-runner:$DEBIAN_RELEASE
 
-ARG PYTHON_VERSION
+ARG PYTHON_VERSION=3.13.7
 # Don't install if python version is already installed.
 # hadolint ignore=DL4006
 RUN if ! pyenv versions --bare | grep $PYTHON_VERSION ; then pyenv install $PYTHON_VERSION ; fi

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,7 +1,7 @@
 ARG DEBIAN_RELEASE=bookworm
 FROM ghcr.io/eiffel-community/etos-base-test-runner:$DEBIAN_RELEASE
 
-ARG RUST_VERSION
+ARG RUST_VERSION=1.90.0
 # hadolint ignore=DL4006
 RUN /usr/bin/curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUST_VERSION
 


### PR DESCRIPTION
### Applicable Issues

### Description of the Change
This PR moves the default build args values from `main.yml` to corresponding `Dockerfile`.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by:  Andrei Matveyeu, andrei.matveyeu@axis.com