### PR TITLE
Update GitHub Actions for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,30 +13,30 @@ jobs:
   run-hadolint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Run hadolint for Base testrunner debian bullseye
-        uses: hadolint/hadolint-action@master
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: base/debian/Dockerfile.bullseye
       - name: Run hadolint for Base testrunner debian bookworm
-        uses: hadolint/hadolint-action@master
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: base/debian/Dockerfile.bookworm
       - name: Run hadolint for Base testrunner ubuntu noble
-        uses: hadolint/hadolint-action@master
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: base/ubuntu/Dockerfile.noble
       - name: Run hadolint for Go
-        uses: hadolint/hadolint-action@master
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: go/Dockerfile
       - name: Run hadolint for Python
-        uses: hadolint/hadolint-action@master
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: python/Dockerfile
       - name: Run hadolint for Rust
-        uses: hadolint/hadolint-action@master
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: rust/Dockerfile
 
@@ -69,13 +69,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -117,10 +117,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -128,17 +128,17 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/eiffel-community/etos-base-test-runner
           tags: |
             type=raw,value=${{ matrix.tag }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}


### PR DESCRIPTION
### Applicable Issues

https://github.com/eiffel-community/etos/issues/595

### Description of the Change

Update 1 workflow file: checkout v2/v4→v6, hadolint/hadolint-action master→v3.3.0, docker/setup-buildx-action v3→v4, docker/build-push-action v5→v7, docker/login-action v3→v4, and docker/metadata-action v5→v6.

### Alternate Designs

_No response_

### Possible Drawbacks

_No response_

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com