### PR TITLE
Replace pyenv with uv for Python and package management

### DIFF
--- a/base/debian/Dockerfile.bookworm
+++ b/base/debian/Dockerfile.bookworm
@@ -28,8 +28,7 @@ WORKDIR /home/etos
 
 # hadolint ignore=DL3013
 RUN uv python install $ETR_PYTHON_VERSION && \
-    uv venv --python $ETR_PYTHON_VERSION && \
-    uv pip install --no-cache etos_test_runner
+    uv venv --python $ETR_PYTHON_VERSION
 
 COPY executor.sh /home/etos/executor.sh
 ENTRYPOINT ["/home/etos/executor.sh"]

--- a/base/debian/Dockerfile.bookworm
+++ b/base/debian/Dockerfile.bookworm
@@ -31,7 +31,7 @@ RUN echo "eval \"\$(pyenv init -)\"" >> /home/etos/.bashrc && \
     pyenv global $ETR_PYTHON_VERSION && \
 	pip install --no-cache-dir -U pip && \
 	pip install --no-cache-dir uv && \
-	uv pip install --no-cache etos_test_runner
+	uv pip install --system --no-cache etos_test_runner
 
 COPY executor.sh /home/etos/executor.sh
 ENTRYPOINT ["/home/etos/executor.sh"]

--- a/base/debian/Dockerfile.bookworm
+++ b/base/debian/Dockerfile.bookworm
@@ -7,6 +7,7 @@ USER root
 
 ENV VIRTUAL_ENV=/home/etos/.venv
 ENV PATH="/home/etos/.venv/bin:${PATH}"
+ENV TEST_FRAMEWORK_VENV=/home/etos/.test-framework
 ENV TEST_ARTIFACT_PATH /home/etos/artifacts
 ENV GLOBAL_ARTIFACT_PATH /home/etos/global
 ENV TEST_LOCAL_PATH /home/etos/local
@@ -28,7 +29,8 @@ WORKDIR /home/etos
 
 # hadolint ignore=DL3013
 RUN uv python install $ETR_PYTHON_VERSION && \
-    uv venv --python $ETR_PYTHON_VERSION
+    uv venv --python $ETR_PYTHON_VERSION && \
+    uv venv --python $ETR_PYTHON_VERSION $TEST_FRAMEWORK_VENV
 
 COPY executor.sh /home/etos/executor.sh
 ENTRYPOINT ["/home/etos/executor.sh"]

--- a/base/debian/Dockerfile.bookworm
+++ b/base/debian/Dockerfile.bookworm
@@ -29,7 +29,9 @@ RUN echo "eval \"\$(pyenv init -)\"" >> /home/etos/.bashrc && \
     git clone https://github.com/pyenv/pyenv.git /home/etos/.pyenv && \
     pyenv install $ETR_PYTHON_VERSION && \
     pyenv global $ETR_PYTHON_VERSION && \
-	pip install --no-cache-dir -U pip
+	pip install --no-cache-dir -U pip && \
+	pip install --no-cache-dir uv && \
+	uv pip install --no-cache etos_test_runner
 
 COPY executor.sh /home/etos/executor.sh
 ENTRYPOINT ["/home/etos/executor.sh"]

--- a/base/debian/Dockerfile.bookworm
+++ b/base/debian/Dockerfile.bookworm
@@ -1,12 +1,12 @@
 FROM debian:bookworm
 
 ENV ETOS_CONTEXT="ETR"
-ENV ETR_PYTHON_VERSION=3.11.2
+ENV ETR_PYTHON_VERSION=3.11
 
 USER root
 
-ENV PYENV_ROOT=/home/etos/.pyenv
-ENV PATH="/home/etos/.pyenv/shims:/home/etos/.pyenv/bin:${PATH}"
+ENV VIRTUAL_ENV=/home/etos/.venv
+ENV PATH="/home/etos/.venv/bin:${PATH}"
 ENV TEST_ARTIFACT_PATH /home/etos/artifacts
 ENV GLOBAL_ARTIFACT_PATH /home/etos/global
 ENV TEST_LOCAL_PATH /home/etos/local
@@ -15,23 +15,21 @@ ENV TEST_LOCAL_PATH /home/etos/local
 RUN apt-get update -y && \
     apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python3-openssl git python3 python3-dev python3-pip \
+    xz-utils tk-dev libffi-dev liblzma-dev git \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd -g 3705 etos && \
     useradd -u 3705 -g 3705 -ms /bin/bash etos
 
+COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /uvx /bin/
+
 USER etos
 WORKDIR /home/etos
 
 # hadolint ignore=DL3013
-RUN echo "eval \"\$(pyenv init -)\"" >> /home/etos/.bashrc && \
-    git clone https://github.com/pyenv/pyenv.git /home/etos/.pyenv && \
-    pyenv install $ETR_PYTHON_VERSION && \
-    pyenv global $ETR_PYTHON_VERSION && \
-	pip install --no-cache-dir -U pip && \
-	pip install --no-cache-dir uv && \
-	uv pip install --system --no-cache etos_test_runner
+RUN uv python install $ETR_PYTHON_VERSION && \
+    uv venv --python $ETR_PYTHON_VERSION && \
+    uv pip install --no-cache etos_test_runner
 
 COPY executor.sh /home/etos/executor.sh
 ENTRYPOINT ["/home/etos/executor.sh"]

--- a/base/debian/Dockerfile.bullseye
+++ b/base/debian/Dockerfile.bullseye
@@ -28,8 +28,7 @@ WORKDIR /home/etos
 
 # hadolint ignore=DL3013
 RUN uv python install $ETR_PYTHON_VERSION && \
-    uv venv --python $ETR_PYTHON_VERSION && \
-    uv pip install --no-cache etos_test_runner
+    uv venv --python $ETR_PYTHON_VERSION
 
 COPY executor.sh /home/etos/executor.sh
 ENTRYPOINT ["/home/etos/executor.sh"]

--- a/base/debian/Dockerfile.bullseye
+++ b/base/debian/Dockerfile.bullseye
@@ -31,7 +31,7 @@ RUN echo "eval \"\$(pyenv init -)\"" >> /home/etos/.bashrc && \
     pyenv global $ETR_PYTHON_VERSION && \
 	pip install --no-cache-dir -U pip && \
 	pip install --no-cache-dir uv && \
-	uv pip install --no-cache etos_test_runner
+	uv pip install --system --no-cache etos_test_runner
 
 COPY executor.sh /home/etos/executor.sh
 ENTRYPOINT ["/home/etos/executor.sh"]

--- a/base/debian/Dockerfile.bullseye
+++ b/base/debian/Dockerfile.bullseye
@@ -7,6 +7,7 @@ USER root
 
 ENV VIRTUAL_ENV=/home/etos/.venv
 ENV PATH="/home/etos/.venv/bin:${PATH}"
+ENV TEST_FRAMEWORK_VENV=/home/etos/.test-framework
 ENV TEST_ARTIFACT_PATH /home/etos/artifacts
 ENV GLOBAL_ARTIFACT_PATH /home/etos/global
 ENV TEST_LOCAL_PATH /home/etos/local
@@ -28,7 +29,8 @@ WORKDIR /home/etos
 
 # hadolint ignore=DL3013
 RUN uv python install $ETR_PYTHON_VERSION && \
-    uv venv --python $ETR_PYTHON_VERSION
+    uv venv --python $ETR_PYTHON_VERSION && \
+    uv venv --python $ETR_PYTHON_VERSION $TEST_FRAMEWORK_VENV
 
 COPY executor.sh /home/etos/executor.sh
 ENTRYPOINT ["/home/etos/executor.sh"]

--- a/base/debian/Dockerfile.bullseye
+++ b/base/debian/Dockerfile.bullseye
@@ -5,8 +5,8 @@ ENV ETR_PYTHON_VERSION=3.13
 
 USER root
 
-ENV PYENV_ROOT=/home/etos/.pyenv
-ENV PATH="/home/etos/.pyenv/shims:/home/etos/.pyenv/bin:${PATH}"
+ENV VIRTUAL_ENV=/home/etos/.venv
+ENV PATH="/home/etos/.venv/bin:${PATH}"
 ENV TEST_ARTIFACT_PATH /home/etos/artifacts
 ENV GLOBAL_ARTIFACT_PATH /home/etos/global
 ENV TEST_LOCAL_PATH /home/etos/local
@@ -15,23 +15,21 @@ ENV TEST_LOCAL_PATH /home/etos/local
 RUN apt-get update -y && \
     apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python3-openssl git python3 python3-dev python3-pip \
+    xz-utils tk-dev libffi-dev liblzma-dev git \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd -g 3705 etos && \
     useradd -u 3705 -g 3705 -ms /bin/bash etos
 
+COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /uvx /bin/
+
 USER etos
 WORKDIR /home/etos
 
 # hadolint ignore=DL3013
-RUN echo "eval \"\$(pyenv init -)\"" >> /home/etos/.bashrc && \
-    git clone https://github.com/pyenv/pyenv.git /home/etos/.pyenv && \
-    pyenv install $ETR_PYTHON_VERSION && \
-    pyenv global $ETR_PYTHON_VERSION && \
-	pip install --no-cache-dir -U pip && \
-	pip install --no-cache-dir uv && \
-	uv pip install --system --no-cache etos_test_runner
+RUN uv python install $ETR_PYTHON_VERSION && \
+    uv venv --python $ETR_PYTHON_VERSION && \
+    uv pip install --no-cache etos_test_runner
 
 COPY executor.sh /home/etos/executor.sh
 ENTRYPOINT ["/home/etos/executor.sh"]

--- a/base/debian/Dockerfile.bullseye
+++ b/base/debian/Dockerfile.bullseye
@@ -29,7 +29,9 @@ RUN echo "eval \"\$(pyenv init -)\"" >> /home/etos/.bashrc && \
     git clone https://github.com/pyenv/pyenv.git /home/etos/.pyenv && \
     pyenv install $ETR_PYTHON_VERSION && \
     pyenv global $ETR_PYTHON_VERSION && \
-	pip install --no-cache-dir -U pip
+	pip install --no-cache-dir -U pip && \
+	pip install --no-cache-dir uv && \
+	uv pip install --no-cache etos_test_runner
 
 COPY executor.sh /home/etos/executor.sh
 ENTRYPOINT ["/home/etos/executor.sh"]

--- a/base/executor.sh
+++ b/base/executor.sh
@@ -26,7 +26,7 @@ else
 fi
 
 log "Installing ETR."
-uv pip install $PIP_ARGS "$ETR_INSTALL"
+uv pip install --system $PIP_ARGS "$ETR_INSTALL"
 log "ETR installed."
 
 log "Executing ETR."

--- a/base/executor.sh
+++ b/base/executor.sh
@@ -26,7 +26,7 @@ else
 fi
 
 log "Installing ETR."
-pip install $PIP_ARGS "$ETR_INSTALL"
+uv pip install $PIP_ARGS "$ETR_INSTALL"
 log "ETR installed."
 
 log "Executing ETR."

--- a/base/executor.sh
+++ b/base/executor.sh
@@ -8,13 +8,7 @@ log() {
     echo "[$(date --iso-8601=seconds)] - $*"
 }
 
-log "Sourcing pyenv."
-eval "$(pyenv init -)"
-
 PIP_ARGS=${PIP_ARG:-""}
-
-log "Setting pyenv shell to version '$ETR_PYTHON_VERSION'."
-pyenv shell "$ETR_PYTHON_VERSION"
 
 DEV=${DEV:-false}
 if [ "$DEV" = "true" ] ; then
@@ -26,7 +20,7 @@ else
 fi
 
 log "Installing ETR."
-uv pip install --system $PIP_ARGS "$ETR_INSTALL"
+uv pip install $PIP_ARGS "$ETR_INSTALL"
 log "ETR installed."
 
 log "Executing ETR."

--- a/base/ubuntu/Dockerfile.noble
+++ b/base/ubuntu/Dockerfile.noble
@@ -28,8 +28,7 @@ WORKDIR /home/etos
 
 # hadolint ignore=DL3013
 RUN uv python install $ETR_PYTHON_VERSION && \
-    uv venv --python $ETR_PYTHON_VERSION && \
-    uv pip install --no-cache etos_test_runner
+    uv venv --python $ETR_PYTHON_VERSION
 
 COPY executor.sh /home/etos/executor.sh
 ENTRYPOINT ["/home/etos/executor.sh"]

--- a/base/ubuntu/Dockerfile.noble
+++ b/base/ubuntu/Dockerfile.noble
@@ -31,7 +31,7 @@ RUN echo "eval \"\$(pyenv init -)\"" >> /home/etos/.bashrc && \
     pyenv global $ETR_PYTHON_VERSION && \
 	pip install --no-cache-dir -U pip && \
 	pip install --no-cache-dir uv && \
-	uv pip install --no-cache etos_test_runner
+	uv pip install --system --no-cache etos_test_runner
 
 COPY executor.sh /home/etos/executor.sh
 ENTRYPOINT ["/home/etos/executor.sh"]

--- a/base/ubuntu/Dockerfile.noble
+++ b/base/ubuntu/Dockerfile.noble
@@ -5,8 +5,8 @@ ENV ETR_PYTHON_VERSION=3.13
 
 USER root
 
-ENV PYENV_ROOT=/home/etos/.pyenv
-ENV PATH="/home/etos/.pyenv/shims:/home/etos/.pyenv/bin:${PATH}"
+ENV VIRTUAL_ENV=/home/etos/.venv
+ENV PATH="/home/etos/.venv/bin:${PATH}"
 ENV TEST_ARTIFACT_PATH=/home/etos/artifacts
 ENV GLOBAL_ARTIFACT_PATH=/home/etos/global
 ENV TEST_LOCAL_PATH=/home/etos/local
@@ -15,23 +15,21 @@ ENV TEST_LOCAL_PATH=/home/etos/local
 RUN apt-get update -y && \
     apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev python3-openssl git python3 python3-dev python3-pip \
+    xz-utils tk-dev libffi-dev liblzma-dev git \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd -g 3705 etos && \
     useradd -u 3705 -g 3705 -ms /bin/bash etos
 
+COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /uvx /bin/
+
 USER etos
 WORKDIR /home/etos
 
 # hadolint ignore=DL3013
-RUN echo "eval \"\$(pyenv init -)\"" >> /home/etos/.bashrc && \
-    git clone https://github.com/pyenv/pyenv.git /home/etos/.pyenv && \
-    pyenv install $ETR_PYTHON_VERSION && \
-    pyenv global $ETR_PYTHON_VERSION && \
-	pip install --no-cache-dir -U pip && \
-	pip install --no-cache-dir uv && \
-	uv pip install --system --no-cache etos_test_runner
+RUN uv python install $ETR_PYTHON_VERSION && \
+    uv venv --python $ETR_PYTHON_VERSION && \
+    uv pip install --no-cache etos_test_runner
 
 COPY executor.sh /home/etos/executor.sh
 ENTRYPOINT ["/home/etos/executor.sh"]

--- a/base/ubuntu/Dockerfile.noble
+++ b/base/ubuntu/Dockerfile.noble
@@ -7,6 +7,7 @@ USER root
 
 ENV VIRTUAL_ENV=/home/etos/.venv
 ENV PATH="/home/etos/.venv/bin:${PATH}"
+ENV TEST_FRAMEWORK_VENV=/home/etos/.test-framework
 ENV TEST_ARTIFACT_PATH=/home/etos/artifacts
 ENV GLOBAL_ARTIFACT_PATH=/home/etos/global
 ENV TEST_LOCAL_PATH=/home/etos/local
@@ -28,7 +29,8 @@ WORKDIR /home/etos
 
 # hadolint ignore=DL3013
 RUN uv python install $ETR_PYTHON_VERSION && \
-    uv venv --python $ETR_PYTHON_VERSION
+    uv venv --python $ETR_PYTHON_VERSION && \
+    uv venv --python $ETR_PYTHON_VERSION $TEST_FRAMEWORK_VENV
 
 COPY executor.sh /home/etos/executor.sh
 ENTRYPOINT ["/home/etos/executor.sh"]

--- a/base/ubuntu/Dockerfile.noble
+++ b/base/ubuntu/Dockerfile.noble
@@ -29,7 +29,9 @@ RUN echo "eval \"\$(pyenv init -)\"" >> /home/etos/.bashrc && \
     git clone https://github.com/pyenv/pyenv.git /home/etos/.pyenv && \
     pyenv install $ETR_PYTHON_VERSION && \
     pyenv global $ETR_PYTHON_VERSION && \
-	pip install --no-cache-dir -U pip
+	pip install --no-cache-dir -U pip && \
+	pip install --no-cache-dir uv && \
+	uv pip install --no-cache etos_test_runner
 
 COPY executor.sh /home/etos/executor.sh
 ENTRYPOINT ["/home/etos/executor.sh"]

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,7 +1,8 @@
 ARG DEBIAN_RELEASE=bookworm
 FROM ghcr.io/eiffel-community/etos-base-test-runner:$DEBIAN_RELEASE
 
+COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /uvx /bin/
+
 ARG PYTHON_VERSION=3.9.18
-# Don't install if python version is already installed.
-# hadolint ignore=DL4006
-RUN if ! pyenv versions --bare | grep $PYTHON_VERSION ; then pyenv install $PYTHON_VERSION ; fi
+# Install additional Python version if not already present.
+RUN uv python install $PYTHON_VERSION


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/672

### Description of the Change

Replace pyenv with uv for Python version management and package installation. Use a PEP 405 virtual environment instead of pyenv shims and pre-install etos_test_runner during image build.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com