### PR TITLE
Install ca-certificates in base test runner images

### DIFF
--- a/base/debian/Dockerfile.bookworm
+++ b/base/debian/Dockerfile.bookworm
@@ -16,7 +16,7 @@ ENV TEST_LOCAL_PATH /home/etos/local
 RUN apt-get update -y && \
     apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev git \
+    xz-utils tk-dev libffi-dev liblzma-dev git ca-certificates \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd -g 3705 etos && \

--- a/base/debian/Dockerfile.bullseye
+++ b/base/debian/Dockerfile.bullseye
@@ -16,7 +16,7 @@ ENV TEST_LOCAL_PATH /home/etos/local
 RUN apt-get update -y && \
     apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev git \
+    xz-utils tk-dev libffi-dev liblzma-dev git ca-certificates \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd -g 3705 etos && \

--- a/base/ubuntu/Dockerfile.noble
+++ b/base/ubuntu/Dockerfile.noble
@@ -16,7 +16,7 @@ ENV TEST_LOCAL_PATH=/home/etos/local
 RUN apt-get update -y && \
     apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev git \
+    xz-utils tk-dev libffi-dev liblzma-dev git ca-certificates \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/* && \
     groupadd -g 3705 etos && \


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/719

### Description of the Change

The pyenv→uv switch dropped the `python3-*`/`python3-openssl` apt packages that had transitively provided `ca-certificates`, leaving the base test runner images without a CA store. This broke HTTPS test checkout (`git clone https://...` failing with `CAfile: none`). Install `ca-certificates` explicitly in the ubuntu-noble, debian-bookworm and debian-bullseye base images.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu <andreimu@axis.com>
